### PR TITLE
Fix dependency type of @iconify-json/emojione-monotone

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,19 +1,23 @@
 {
   "name": "slidev-addon-rabbit",
-  "version": "0.1.0",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "slidev-addon-rabbit",
-      "version": "0.1.0",
+      "version": "0.3.0",
       "license": "MIT",
       "dependencies": {
-        "@slidev/theme-default": "^0.21.2"
+        "@iconify-json/emojione-monotone": "^1.1.4"
       },
       "devDependencies": {
-        "@iconify-json/emojione-monotone": "^1.1.4",
-        "@slidev/cli": "^0.43.7"
+        "@slidev/cli": "^0.43.7",
+        "@slidev/theme-default": "^0.21.2"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=9.5.0"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -887,7 +891,6 @@
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/@iconify-json/emojione-monotone/-/emojione-monotone-1.1.5.tgz",
       "integrity": "sha512-r1SBrQ0jrlPFHN8RMxoPJjuoBheq/vo3vXE8gu61odRlgzzvThQ0Cg1InUwQkAKr12Wz8X/41QfLYL9HwNcb5w==",
-      "dev": true,
       "dependencies": {
         "@iconify/types": "*"
       }
@@ -904,8 +907,7 @@
     "node_modules/@iconify/types": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@iconify/types/-/types-2.0.0.tgz",
-      "integrity": "sha512-+wluvCrRhXrhyOmRDJ3q8mux9JkKy5SJ/v8ol2tu4FVjyYvtEzkc/3pK15ET6RKg4b4w4BmTk1+gsCUhf21Ykg==",
-      "dev": true
+      "integrity": "sha512-+wluvCrRhXrhyOmRDJ3q8mux9JkKy5SJ/v8ol2tu4FVjyYvtEzkc/3pK15ET6RKg4b4w4BmTk1+gsCUhf21Ykg=="
     },
     "node_modules/@iconify/utils": {
       "version": "2.1.11",
@@ -1349,6 +1351,7 @@
       "version": "0.21.2",
       "resolved": "https://registry.npmjs.org/@slidev/theme-default/-/theme-default-0.21.2.tgz",
       "integrity": "sha512-neUucFs2YrRZZd73QwvLTyRG/o1nerDFUR5t8YAmXVLTMzWfY71flQ6aAhjYf+WjsozYsOHcxi/pZtIzZ4VhTQ==",
+      "dev": true,
       "dependencies": {
         "@slidev/types": "^0.22.7",
         "codemirror-theme-vars": "^0.1.1",
@@ -1367,6 +1370,7 @@
       "version": "0.22.7",
       "resolved": "https://registry.npmjs.org/@slidev/types/-/types-0.22.7.tgz",
       "integrity": "sha512-mCVKQbcGTv6d6n9aHpYNp5U04HF+FMbpY083vqpJ6Folc805BB1Am02eubaW0J6nM+dSOu2dDgPY+kIjs75sAQ==",
+      "dev": true,
       "engines": {
         "node": ">=14.0.0"
       },
@@ -2719,6 +2723,7 @@
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/codemirror-theme-vars/-/codemirror-theme-vars-0.1.2.tgz",
       "integrity": "sha512-WTau8X2q58b0SOAY9DO+iQVw8JKVEgyQIqArp2D732tcc+pobbMta3bnVMdQdmgwuvNrOFFr6HoxPRoQOgooFA==",
+      "dev": true,
       "funding": {
         "url": "https://github.com/sponsors/antfu"
       }
@@ -6413,6 +6418,7 @@
       "version": "0.2.4",
       "resolved": "https://registry.npmjs.org/prism-theme-vars/-/prism-theme-vars-0.2.4.tgz",
       "integrity": "sha512-B3Pht+GCT87sZph7hMRLlCQXzCM0awW7Rhk08RavpqRW4LEQOeqN0uMG4QCWkul2tr8PB61YAOJGUrEW+1uuJA==",
+      "dev": true,
       "funding": {
         "url": "https://github.com/sponsors/antfu"
       }
@@ -7016,6 +7022,7 @@
       "version": "0.1.14",
       "resolved": "https://registry.npmjs.org/theme-vitesse/-/theme-vitesse-0.1.14.tgz",
       "integrity": "sha512-b5s+Zpfaw5+djoCJ9AEbcTbpiTlLsOvGM9oblDmmWRGWNqg9oXtEYO/uwubwx77novHBI6zNuwZRHKNlAIBo4A==",
+      "dev": true,
       "engines": {
         "vscode": "^1.43.0"
       }

--- a/package.json
+++ b/package.json
@@ -24,11 +24,11 @@
   "author": "kaakaa",
   "license": "MIT",
   "devDependencies": {
-    "@iconify-json/emojione-monotone": "^1.1.4",
-    "@slidev/cli": "^0.43.7"
+    "@slidev/cli": "^0.43.7",
+    "@slidev/theme-default": "^0.21.2"
   },
   "dependencies": {
-    "@slidev/theme-default": "^0.21.2"
+    "@iconify-json/emojione-monotone": "^1.1.4"
   },
   "bugs": {
     "url": "https://github.com/kaakaa/slidev-addon-rabbit/issues"


### PR DESCRIPTION
## Summary

Move `@iconify-json/emojione-monotone` from `devDependencies` to `dependencies` to take it in npm module.

Fix #3 