### PR TITLE
Make rabbit reaching the goal when slideNum is false

### DIFF
--- a/components/Rabbit.vue
+++ b/components/Rabbit.vue
@@ -17,12 +17,12 @@
 <script setup>
 import { computed } from 'vue';
 
+const showSlideNum = $slidev.configs?.rabbit?.slideNum ?? false;
+
 const total = $slidev.nav.total;
 const canvasWidth = $slidev.configs.canvasWidth;
-const tooltipWidth = 60;
+const tooltipWidth = showSlideNum ? 60 : 0;
 const marginRight = 20; // To display rabbit icon on last page
-
-const showSlideNum = $slidev.configs?.rabbit?.slideNum ?? false;
 
 const props = defineProps({
   current: Number,


### PR DESCRIPTION
## Summary 

With `slideNum: false`, rabbit never reach the goal. This PR fix it.

<img width="745" alt="image" src="https://github.com/user-attachments/assets/82618776-5222-4423-9f12-6da94a09368b">
